### PR TITLE
router don't swallow RESET action if it's not for itself, thus childR…

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -480,7 +480,7 @@ export default (routeConfigs, stackConfig = {}) => {
         }
       }
 
-      if (action.type === StackActions.RESET) {
+      if (action.type === StackActions.RESET && (action.key === null || action.key == state.key)) {
         // Only handle reset actions that are unspecified or match this state key
         if (action.key != null && action.key != state.key) {
           // Deliberately use != instead of !== so we can match null with
@@ -581,7 +581,8 @@ export default (routeConfigs, stackConfig = {}) => {
               // because people don't expect these actions to switch the active route
               action.type === NavigationActions.SET_PARAMS ||
                 action.type === StackActions.COMPLETE_TRANSITION ||
-                action.type.includes('DRAWER')
+                action.type.includes('DRAWER') ||
+                action.type === StackActions.RESET
             );
           }
         }

--- a/src/routers/SwitchRouter.js
+++ b/src/routers/SwitchRouter.js
@@ -14,6 +14,7 @@ function childrenUpdateWithoutSwitchingIndex(actionType) {
     NavigationActions.SET_PARAMS,
     // Todo: make SwitchRouter not depend on StackActions..
     StackActions.COMPLETE_TRANSITION,
+    StackActions.RESET,
   ].includes(actionType);
 }
 


### PR DESCRIPTION
…outers will have chance to react to RESET action

(eg: stack inside stack, stack inside tab)

add StackActions.RESET to SwitchRouter's childrenUpdateWithoutSwitchingIndex whitelist


Works in my use case(with key provided, only reset the corresponding stack).
Ignore if this is useless.