### PR TITLE
Add DROP action for StackRouter;  handle “shouldDropStackOnTransitionComplete” param in NAVIGATE action

### DIFF
--- a/src/NavigationActions.js
+++ b/src/NavigationActions.js
@@ -35,6 +35,10 @@ export const navigate = payload => {
   if (payload.key) {
     action.key = payload.key;
   }
+  if (payload.shouldDropStackOnTransitionComplete) {
+    action.shouldDropStackOnTransitionComplete =
+      payload.shouldDropStackOnTransitionComplete;
+  }
   return action;
 };
 

--- a/src/StateUtils.js
+++ b/src/StateUtils.js
@@ -199,6 +199,18 @@ const StateUtils = {
       routes,
     };
   },
+
+  drop(state) {
+    if (state.index > 0) {
+      return {
+        ...state,
+        index: 0,
+        routes: [state.routes[state.index]],
+      };
+    }
+
+    return state;
+  },
 };
 
 export default StateUtils;

--- a/src/routers/StackActions.js
+++ b/src/routers/StackActions.js
@@ -1,9 +1,15 @@
+export const DROP = 'Navigation/DROP';
 export const POP = 'Navigation/POP';
 export const POP_TO_TOP = 'Navigation/POP_TO_TOP';
 export const PUSH = 'Navigation/PUSH';
 export const RESET = 'Navigation/RESET';
 export const REPLACE = 'Navigation/REPLACE';
 export const COMPLETE_TRANSITION = 'Navigation/COMPLETE_TRANSITION';
+
+export const drop = key => ({
+  type: DROP,
+  key,
+});
 
 export const pop = payload => ({
   type: POP,

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -142,6 +142,7 @@ export default (routeConfigs, stackConfig = {}) => {
     getActionCreators(route, navStateKey) {
       return {
         ...getCustomActionCreators(route, navStateKey),
+        drop: (key = navStateKey) => StackActions.drop(key),
         pop: (n, params) =>
           StackActions.pop({
             n,
@@ -409,6 +410,19 @@ export default (routeConfigs, stackConfig = {}) => {
             routes: [state.routes[0]],
           };
         }
+        return state;
+      }
+
+      // Handle drop action
+      if (action.type === StackActions.DROP) {
+        if (state && state.key === action.key) {
+          return {
+            ...StateUtils.drop(state),
+            shouldDropStackOnTransitionComplete: undefined,
+            isTransitioning: false,
+          };
+        }
+
         return state;
       }
 

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -344,6 +344,8 @@ export default (routeConfigs, stackConfig = {}) => {
         return {
           ...StateUtils.push(state, route),
           isTransitioning: action.immediate !== true,
+          shouldDropStackOnTransitionComplete:
+            action.shouldDropStackOnTransitionComplete,
         };
       } else if (
         action.type === StackActions.PUSH &&
@@ -469,7 +471,10 @@ export default (routeConfigs, stackConfig = {}) => {
         state.isTransitioning
       ) {
         return {
-          ...state,
+          ...(state.shouldDropStackOnTransitionComplete
+            ? StateUtils.drop(state)
+            : state),
+          shouldDropStackOnTransitionComplete: undefined,
           isTransitioning: false,
         };
       }


### PR DESCRIPTION
This pull request adds functionality to remove all not active (hidden) screens in stack. You can do it in three ways
1. Using `drop` action creator, it drops the stack in which it was used
```
this.props.navigation.drop()
```
2. Using `DROP` action
```
this.props.navigation.dispatch({ type: StackActions.DROP, key: 'StackRouterRoot' })
```
3. Drop stack on complete transition to a new screen
```
this.props.navigation.dispatch(NavigationActions.navigate({
  routeName: 'Home',
  shouldDropStackOnTransitionComplete: true,
})
```

Motivation
1. Performance Improvement: in some cases bottom screen is not needed any more after it was overlapped with the next active screen, but it is still mounted, takes memory and even can affect active screen if there are some active listeners on it, that change global state.

2. UX Improvement: there are scenarios in which we need to be sure on 100% that user experience starts from a blank page, e.g, Onboarding flow has finished and we should open Home screen, some payment flows where you need to be totally sure that PaymentStart screen is a first screen in the flow and there was nothing before it.

Issues
1. `this.props.navigation.isFirstRouteInParent()` will return incorrect value after DROP action. I thought a lot about this and I think we should remove this Api in favor of future History Api, plus as @satya164 [said](https://github.com/react-navigation/react-navigation-core/pull/51#issuecomment-480827256) it only works if something triggers re-rendering.
There should be a History Api. It should allow developer to see history length, current screen history index, active screen history index (maybe), go back and go forward in history. As this is an additional payload on every action it should be optional and turned off by default (`useHistory` property in StackRouter config). Plus if you don't want to re-render active route on history index change, you should be able to avoid this. So we need something like `mapHistoryToProps`.
If there are people who really need this functionality, I can implement it after discussion.

P.S. If you want to, I can rename `shouldDropStackOnTransitionComplete` to `dropStack`. Just wanted to be as explicit as possible.
P.S.S. I tested this functionality in our real app [Preggers](https://itunes.apple.com/se/app/preggers-gravid-och-baby-app/id1363479578) and everything works as expected. It should be in production next week.