### PR TITLE
fix: getScreen getting called for each route on init

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -30,7 +30,9 @@ export default (routeConfigs, stackConfig = {}) => {
 
   // Loop through routes and find child routers
   routeNames.forEach(routeName => {
-    const screen = getScreenForRouteName(routeConfigs, routeName);
+    const routeConfig = routeConfigs[routeName];
+    const screen =
+      routeConfig && routeConfig.screen ? routeConfig.screen : routeConfig;
     if (screen && screen.router) {
       // If it has a router it's a navigator.
       childRouters[routeName] = screen.router;


### PR DESCRIPTION
`getScreenForRouteName` will call `getScreen` which we don't want since it breaks routes lazy loading.

The only caveat is that screens that have a child navigation can not use `getScreen`.