### PR TITLE
feat: support string array for uriPrefix

### DIFF
--- a/src/routers/__tests__/pathUtils-test.js
+++ b/src/routers/__tests__/pathUtils-test.js
@@ -24,11 +24,47 @@ it('urlToPathAndParams with params', () => {
   expect(params).toEqual({ asdf: '1', dude: 'foo' });
 });
 
-it('urlToPathAndParams with custom delimeter', () => {
+it('urlToPathAndParams with custom delimeter string', () => {
   const { path, params } = urlToPathAndParams(
     'https://example.com/foo/bar?asdf=1',
     'https://example.com/'
   );
+  expect(path).toBe('foo/bar');
+  expect(params).toEqual({ asdf: '1' });
+});
+
+it('urlToPathAndParams with custom delimeter RegExp', () => {
+  const { path, params } = urlToPathAndParams(
+    'https://example.com/foo/bar?asdf=1',
+    new RegExp('https://example.com/')
+  );
+  expect(path).toBe('foo/bar');
+  expect(params).toEqual({ asdf: '1' });
+});
+
+it('urlToPathAndParams with duplicate prefix in query parameters', () => {
+  const { path, params } = urlToPathAndParams(
+    'example://whatever?related=example://something',
+    'example://'
+  );
+  expect(path).toBe('whatever');
+  expect(params).toEqual({ related: 'example://something' });
+});
+
+it('urlToPathAndParams with array of custom delimiters, should use first match', () => {
+  const { path, params } = urlToPathAndParams(
+    'https://example.com/foo/bar?asdf=1',
+    ['baz', 'https://example.com/', 'https://example.com/foo']
+  );
+  expect(path).toBe('foo/bar');
+  expect(params).toEqual({ asdf: '1' });
+});
+
+it('urlToPathAndParams with array of custom delimiters where none match, should resort to default delimiter', () => {
+  const { path, params } = urlToPathAndParams('foo://foo/bar?asdf=1', [
+    'baz',
+    'bazzlefraz',
+  ]);
   expect(path).toBe('foo/bar');
   expect(params).toEqual({ asdf: '1' });
 });

--- a/src/routers/pathUtils.js
+++ b/src/routers/pathUtils.js
@@ -43,8 +43,8 @@ const getRestOfPath = (pathMatch, pathMatchKeys) => {
 const determineDelimiter = (uri, uriPrefix) => {
   if (Array.isArray(uriPrefix)) {
     if (uriPrefix.length === 1) return uriPrefix[0];
-    for (let prefix of uriPrefix) {
-      if (uri.includes(prefix)) return prefix;
+    for (let startsWith of uriPrefix) {
+      if (uri.includes(startsWith)) return startsWith;
     }
     return null;
   }

--- a/src/routers/pathUtils.js
+++ b/src/routers/pathUtils.js
@@ -40,14 +40,25 @@ const getRestOfPath = (pathMatch, pathMatchKeys) => {
   return rest;
 };
 
+const determineDelimiter = (uri, uriPrefix) => {
+  if (Array.isArray(uriPrefix)) {
+    if (uriPrefix.length === 1) return uriPrefix[0];
+    for (let prefix of uriPrefix) {
+      if (uri.includes(prefix)) return prefix;
+    }
+    return null;
+  }
+  return uriPrefix;
+};
+
 export const urlToPathAndParams = (url, uriPrefix) => {
   const searchMatch = url.match(/^(.*)\?(.*)$/);
-  const params = searchMatch ? queryString.parse(searchMatch[2]) : {};
-  const urlWithoutSearch = searchMatch ? searchMatch[1] : url;
-  const delimiter = uriPrefix || '://';
-  let path = urlWithoutSearch.split(delimiter)[1];
+  const [, urlWithoutQuery, query] = searchMatch || [null, url, {}];
+  const params = queryString.parse(query);
+  const delimiter = determineDelimiter(urlWithoutQuery, uriPrefix) || '://';
+  let path = urlWithoutQuery.split(delimiter)[1];
   if (path === undefined) {
-    path = urlWithoutSearch;
+    path = urlWithoutQuery;
   }
   if (path === '/') {
     path = '';

--- a/src/routers/pathUtils.js
+++ b/src/routers/pathUtils.js
@@ -43,8 +43,8 @@ const getRestOfPath = (pathMatch, pathMatchKeys) => {
 const determineDelimiter = (uri, uriPrefix) => {
   if (Array.isArray(uriPrefix)) {
     if (uriPrefix.length === 1) return uriPrefix[0];
-    for (let startsWith of uriPrefix) {
-      if (uri.includes(startsWith)) return startsWith;
+    for (let prefix of uriPrefix) {
+      if (uri.startsWith(prefix)) return prefix;
     }
     return null;
   }


### PR DESCRIPTION
Motivation:
Users often need a way to match multiple prefixes. RegExp can often be difficult to re-interpret or edit once written, while an array of strings is easier to understand and maintain.

Changes:
- use of destructuring to make variable names more explicit
- added function to handle uriPrefix permutations (string|RegExp|array) to keep `urlToPathAndParams` logic simple

Fixes https://github.com/react-navigation/react-navigation/issues/1455 and fixes https://github.com/react-navigation/react-navigation/issues/4887