### PR TITLE
wip: removed code block that prevents event dispatch

### DIFF
--- a/src/getChildEventSubscriber.js
+++ b/src/getChildEventSubscriber.js
@@ -184,12 +184,6 @@ export default function getChildEventSubscriber(
       return { remove };
     },
     emit(eventName, payload) {
-      if (eventName !== 'refocus') {
-        console.error(
-          `navigation.emit only supports the 'refocus' event currently.`
-        );
-        return;
-      }
       emit(eventName, payload);
     },
   };

--- a/src/getChildEventSubscriber.js
+++ b/src/getChildEventSubscriber.js
@@ -9,51 +9,16 @@ export default function getChildEventSubscriber(
   key,
   initialLastFocusEvent = 'didBlur'
 ) {
-  const actionSubscribers = new Set();
-  const willFocusSubscribers = new Set();
-  const didFocusSubscribers = new Set();
-  const willBlurSubscribers = new Set();
-  const didBlurSubscribers = new Set();
-  const refocusSubscribers = new Set();
-  const drawerOpenSubscribers = new Set();
-  const drawerCloseSubscribers = new Set();
+  const eventSubscribers = new Map();
 
   const removeAll = () => {
-    [
-      actionSubscribers,
-      willFocusSubscribers,
-      didFocusSubscribers,
-      willBlurSubscribers,
-      didBlurSubscribers,
-      refocusSubscribers,
-      drawerOpenSubscribers,
-      drawerCloseSubscribers,
-    ].forEach(set => set.clear());
+    eventSubscribers.forEach(set => set.clear());
 
     upstreamSubscribers.forEach(subs => subs && subs.remove());
   };
 
   const getChildSubscribers = evtName => {
-    switch (evtName) {
-      case 'action':
-        return actionSubscribers;
-      case 'willFocus':
-        return willFocusSubscribers;
-      case 'didFocus':
-        return didFocusSubscribers;
-      case 'willBlur':
-        return willBlurSubscribers;
-      case 'didBlur':
-        return didBlurSubscribers;
-      case 'refocus':
-        return refocusSubscribers;
-      case 'drawerOpen':
-        return drawerOpenSubscribers;
-      case 'drawerClose':
-        return drawerCloseSubscribers;
-      default:
-        return null;
-    }
+    return eventSubscribers.get(evtName);
   };
 
   const emit = (type, payload) => {
@@ -84,6 +49,9 @@ export default function getChildEventSubscriber(
 
   const upstreamSubscribers = upstreamEvents.map(eventName =>
     addListener(eventName, payload => {
+      if (!eventSubscribers.has(eventName)) {
+        eventSubscribers.set(eventName, new Set());
+      }
       if (
         eventName === 'refocus' ||
         eventName === 'drawerOpen' ||

--- a/src/getChildEventSubscriber.js
+++ b/src/getChildEventSubscriber.js
@@ -15,6 +15,8 @@ export default function getChildEventSubscriber(
   const willBlurSubscribers = new Set();
   const didBlurSubscribers = new Set();
   const refocusSubscribers = new Set();
+  const drawerOpenSubscribers = new Set();
+  const drawerCloseSubscribers = new Set();
 
   const removeAll = () => {
     [
@@ -24,6 +26,8 @@ export default function getChildEventSubscriber(
       willBlurSubscribers,
       didBlurSubscribers,
       refocusSubscribers,
+      drawerOpenSubscribers,
+      drawerCloseSubscribers,
     ].forEach(set => set.clear());
 
     upstreamSubscribers.forEach(subs => subs && subs.remove());
@@ -43,6 +47,10 @@ export default function getChildEventSubscriber(
         return didBlurSubscribers;
       case 'refocus':
         return refocusSubscribers;
+      case 'drawerOpen':
+        return drawerOpenSubscribers;
+      case 'drawerClose':
+        return drawerCloseSubscribers;
       default:
         return null;
     }
@@ -70,11 +78,17 @@ export default function getChildEventSubscriber(
     'didBlur',
     'refocus',
     'action',
+    'drawerOpen',
+    'drawerClose',
   ];
 
   const upstreamSubscribers = upstreamEvents.map(eventName =>
     addListener(eventName, payload => {
-      if (eventName === 'refocus') {
+      if (
+        eventName === 'refocus' ||
+        eventName === 'drawerOpen' ||
+        eventName === 'drawerClose'
+      ) {
         emit(eventName, payload);
         return;
       }


### PR DESCRIPTION
Removed code block which prevents any other event (besides 'refocus') from being dispatched

## Related Issue and Pull Request
[React Navigation Drawer Issue 11](https://github.com/react-navigation/drawer/issues/11)
[React Navigation Drawer Pull Request 128](https://github.com/react-navigation/drawer/pull/128)